### PR TITLE
Delete unnecessary variable assignation

### DIFF
--- a/examples/pulse-white.py
+++ b/examples/pulse-white.py
@@ -9,8 +9,6 @@ import motephat
 
 motephat.set_brightness(1)
 
-offset = 0
-
 while True:
     br = (math.sin(time.time()) + 1) / 2
     br *= 255.0


### PR DESCRIPTION
The variable 'offset' in pulse-white.py is unnecessary.